### PR TITLE
test_tcp_port: ensure no type error on macOS

### DIFF
--- a/r/src/test_tcp_port.c
+++ b/r/src/test_tcp_port.c
@@ -8,6 +8,12 @@
 #include <netinet/in.h>
 #endif
 
+#ifdef __APPLE__
+  #ifndef u_int32_t
+    typedef uint32_t u_int32_t;
+  #endif
+#endif
+
 // Adopted from https://github.com/ropensci/ssh/blob/master/src/tunnel.c
 // which is released under the MIT license
 static int test_tcp_port(int port) {


### PR DESCRIPTION
This is a fix for possible type conflict arising apparently from Apple headers. There is no problem with the package code itself.